### PR TITLE
Don't use auto in lambda functions

### DIFF
--- a/src/supercluster.cpp
+++ b/src/supercluster.cpp
@@ -97,7 +97,7 @@ std::vector<Cluster*> SuperCluster::cluster(const std::vector<Cluster*> &points,
         double wx = p->point.first * numPoints;
         double wy = p->point.second * numPoints;
 
-        tree->kdbush->within(p->point.first, p->point.second, radius, [&foundNeighbors, &numPoints, tree, &wx, &wy, zoom](const auto id) {
+        tree->kdbush->within(p->point.first, p->point.second, radius, [&foundNeighbors, &numPoints, tree, &wx, &wy, zoom](const std::vector<Cluster*>::size_type id) {
             Cluster *b = tree->clusters[id];
             if (zoom < b->zoom) {
                 foundNeighbors = true;
@@ -127,7 +127,7 @@ std::vector<Cluster*> SuperCluster::getClusters(const Point &min_p, const Point 
     std::vector<Cluster*> clusters;
 
     ClusterTree *tree = trees[z];
-    tree->kdbush->range(min_p.first, min_p.second, max_p.first, max_p.second, [&clusters, &tree](const auto id) {
+    tree->kdbush->range(min_p.first, min_p.second, max_p.first, max_p.second, [&clusters, &tree](const std::vector<Cluster*>::size_type id) {
         clusters.push_back(tree->clusters[id]);
     });
 


### PR DESCRIPTION
It seems that using auto in lambda functions is supported as of C++14, but not C++1y, which is used here.

This is also unsupported in gcc-4.8. While this is uglier to read it fixes compilation for older gcc versions that support c++1y, but not c++14.

An example platform that is affected is Amazon Linux 1, which is used in
AWS Lambda functions. Therefore, this fix allows pysupercluster to be
compiled and used in AWS Lambda functions.