### PR TITLE
Poetry installation fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,19 @@ with open(readme_file, encoding="utf-8") as f:
 class build_ext(_build_ext):
     def finalize_options(self):
         _build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
 
+        # Prevent numpy from thinking it is still in its setup process:
+        try:
+            __builtins__.__NUMPY_SETUP__ = False
+        except:
+            try:
+                # For python 3
+                import builtins
+                builtins.__NUMPY_SETUP__ = False
+            except:
+                warn("Skipping numpy hack; if installation fails, try installing numpy first")
+
+        import numpy
         self.include_dirs.append(numpy.get_include())
 
 


### PR DESCRIPTION
When installing this with Poetry on Python 3.8.1, setup.py was throwing an error: `AttributeError: 'dict' object has no attribute '__NUMPY_SETUP__'`

This fallback fix seemed to work for another project https://github.com/RaRe-Technologies/gensim/issues/3362 and was tested locally.